### PR TITLE
Related Articles header

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -63,7 +63,7 @@
     	{% endif %}
 		{% if config.plugins.relatedpages.enabled and related_pages|length > 0 %}
     	<div class="related topiclist">
-    		<h2>{{ 'RELATED_ARTICLES'|t }}Related Articles</h2>
+    		<h2>{{ 'RELATED_ARTICLES'|t }}</h2>
 		    {% include 'partials/relatedpages.html.twig' %}
     	</div>
 		{% endif %}    		


### PR DESCRIPTION
I removed the text "Related Articles" on line 66, I'm using a dutch translation, and it showed the title double, once in dutch, and directly after that the one declared on line 66 (Related Articles).