### PR TITLE
Add possibility to describe categories, as for authors

### DIFF
--- a/templates/category.html.twig
+++ b/templates/category.html.twig
@@ -1,0 +1,11 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block content %}
+	<h1>{{ 'CATEGORY'|t }} {{ page.header.category }}</h1>
+	{{ page.content }}	
+
+	<h2>{{ 'ARTICLE_CATEGORIES'|t }}</h2>
+	{% include 'partials/frontlist.html.twig' with {'category': page.header.category} %}
+{% endblock %}
+
+

--- a/templates/taxonomy.html.twig
+++ b/templates/taxonomy.html.twig
@@ -29,7 +29,14 @@
                     <h1>Categories</h1>
                     <ul>
                     {% for cat in catlist|sort %}
-                        <li><a href="{{ base_url }}/taxonomy?name=category&amp;val={{ cat|url_encode }}">{{ cat }}</a></li>
+                        {# Check to see if a dedicated category page exists #}
+                        {% set slug = cat|hyphenize|url_encode %}
+                        {% set p = page.find('/categories/'~slug) %}
+                        {% if p == null %}
+                                <li><a href="{{ base_url }}/taxonomy?name=category&amp;val={{ cat|url_encode }}">{{ cat }}</a></li>
+                        {% else %}
+                                <li><a href="{{ base_url }}/categories/{{slug}}">{{ cat }}</a></li>
+                        {% endif %}
                     {% endfor %}
                     </ul>
                 </section>


### PR DESCRIPTION
I had a need to describe categories as we can describe authors in my own installation of Knowledge base theme.

So I have adapted what has been done for Authors (both `author.html.twig` and the specific part in `taxonomy.html.twig`).

