### PR TITLE
Links to article source in a git system

### DIFF
--- a/knowledge-base.yaml
+++ b/knowledge-base.yaml
@@ -11,6 +11,9 @@ params:
       authors: true   # show article authors in the article header
       topics: true    # show assigned topics in the article header
       time: true      # show reading time in the article header
+    git:
+      tree: https://github.com/Perlkonig/grav-skeleton-knowledge-base/blob/master/ 
+      commits: https://github.com/Perlkonig/grav-skeleton-knowledge-base/commits/master/
   front:              # params for the front page content
     maxrows: 3        # the maximum number of rows on the front page
     maxentries: 5     # maximum number of articles displayed for each category

--- a/languages.yaml
+++ b/languages.yaml
@@ -10,6 +10,8 @@ en:
     RELATED_ARTICLES: Related Articles
     COMMENTS: Comments
     CATEGORY: "Category:"
+    GIT_PAGE_EDIT: "Edit this page"
+    GIT_PAGE_HISTORY: "View history"
 fr:
     FOOTER_TEXT: <p><a href="https://github.com/Perlkonig/grav-theme-knowledge-base">Ce thème</a> à été <i class="fa fa-code"></i> avec <i class="fa fa-heart"></i> par <a href="http://perlkonig.com">Perlk&ouml;nig</a>.</p>
     CATEGORIES: Catégories
@@ -22,6 +24,8 @@ fr:
     RELATED_ARTICLES: Articles similaires
     COMMENTS: Commentaires
     CATEGORY: "Catégorie : "
+    GIT_PAGE_EDIT: "Editer cette page"
+    GIT_PAGE_HISTORY: "Voir l'historique"
 cs:
     FOOTER_TEXT: <p><a href="https://github.com/Perlkonig/grav-theme-knowledge-base">Tento motiv</a> byl <i class="fa fa-code"></i>-án s <i class="fa fa-heart"></i> uživatelem <a href="http://perlkonig.com">Perlk&ouml;nig</a>.</p>
     CATEGORIES: Kategorie

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -40,6 +40,12 @@
 		{% if grav.theme.config.params.articles.show.time %}
 			<span>{{ page.content|readingtime }}</span>
 		{% endif %}
+		{% if grav.theme.config.params.articles.git.tree %}
+			<span>{% include 'partials/git_edit_link.html.twig' %}</span>
+		{% endif %}
+		{% if grav.theme.config.params.articles.git.commits %}
+			<span>{% include 'partials/git_history_link.html.twig' %}</span>
+		{% endif %}
 		</div>
 	{% endif %}
 	</section>

--- a/templates/partials/git_edit_link.html.twig
+++ b/templates/partials/git_edit_link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link" href="{{ grav.theme.config.params.articles.git.tree ~  ('/'~page.filePathClean)|regex_replace( '@/user/sites/[a-zA-Z0-9_-]+/@' , '' ) }}"><i class="fa fa-git-square"></i> {{ 'GIT_PAGE_EDIT'|t }}</a>
+<a class="github-link" href="{{ grav.theme.config.params.articles.git.tree ~  ('/'~page.filePathClean)|regex_replace( '@/user(?:/sites/[a-zA-Z0-9_-]+)?/@' , '' ) }}"><i class="fa fa-git-square"></i> {{ 'GIT_PAGE_EDIT'|t }}</a>

--- a/templates/partials/git_edit_link.html.twig
+++ b/templates/partials/git_edit_link.html.twig
@@ -1,0 +1,1 @@
+<a class="github-link" href="{{ grav.theme.config.params.articles.git.tree ~  ('/'~page.filePathClean)|regex_replace( '@/user/sites/[a-zA-Z0-9_-]+/@' , '' ) }}"><i class="fa fa-git-square"></i> {{ 'GIT_PAGE_EDIT'|t }}</a>

--- a/templates/partials/git_history_link.html.twig
+++ b/templates/partials/git_history_link.html.twig
@@ -1,0 +1,1 @@
+<a class="github-link" href="{{ grav.theme.config.params.articles.git.commits ~  ('/'~page.filePathClean)|regex_replace( '@/user/sites/[a-zA-Z0-9_-]+/@' , '' ) }}"><i class="fa fa-history"></i> {{ 'GIT_PAGE_HISTORY'|t }}</a>

--- a/templates/partials/git_history_link.html.twig
+++ b/templates/partials/git_history_link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link" href="{{ grav.theme.config.params.articles.git.commits ~  ('/'~page.filePathClean)|regex_replace( '@/user/sites/[a-zA-Z0-9_-]+/@' , '' ) }}"><i class="fa fa-history"></i> {{ 'GIT_PAGE_HISTORY'|t }}</a>
+<a class="github-link" href="{{ grav.theme.config.params.articles.git.commits ~  ('/'~page.filePathClean)|regex_replace( '@/user(?:/sites/[a-zA-Z0-9_-]+)?/@' , '' ) }}"><i class="fa fa-history"></i> {{ 'GIT_PAGE_HISTORY'|t }}</a>


### PR DESCRIPTION
This is a functionnality available in Learn2 theme and really interresting when you are creating a documentation.

This PR add the possibility to have in the pages of the articles two links to Git management system (Github, Gitlab or other) to go directly on the source of the article for the first one (Edit this page) or to the history of commits for the second one (View history).

I have added two params in `articles`, one with the link to the tree, one with the link to the commits. If the parameter is missing in the config file, the link is not shown in the article.

It works for both single Grav site and multisite.

There is no request from other for that function, but as it was something needed for me, I share it ;)